### PR TITLE
add support for engine play

### DIFF
--- a/src/backend/game_server/src/consts.py
+++ b/src/backend/game_server/src/consts.py
@@ -23,6 +23,7 @@ STATUS = 'status'
 
 NAME = "name"
 RATING = "rating"
+PLAYER_TYPE = "player_type"
 RATING_DELTA = "rating_delta"
 CONNECT_STATUS = "connection_status"
 PREFERENCES = "preferences"

--- a/src/backend/game_server/src/server_response.py
+++ b/src/backend/game_server/src/server_response.py
@@ -47,7 +47,7 @@ class EndGameInfo:
                            white_rating_delta=white_rating_delta, black_rating_delta=black_rating_delta)
 
 class ServerResponse:
-    def __init__(self, dst_sid: str, src_sid:str = None, src_color: str = None, dst_color: str = None,
+    def __init__(self, dst_sid: str, src_sid: str = None, src_color: str = None, dst_color: str = None,
                  result: Result = None, end_game_info: EndGameInfo = None, extra_data: dict = None):
         self.dst_sid = dst_sid
         self.src_sid = src_sid

--- a/src/backend/game_server/src/util.py
+++ b/src/backend/game_server/src/util.py
@@ -65,3 +65,7 @@ class Outcome(Enum):
     SECOND_PLAYER_WINS = 2
     DRAW = 0
     NO_GAME = 3
+
+class PlayerType(Enum):
+    HUMAN = 0
+    ENGINE = 1

--- a/src/frontend/Caddyfile
+++ b/src/frontend/Caddyfile
@@ -28,6 +28,7 @@ route {
         root * static/
         reverse_proxy @notStatic {$BE_URL}:5000
         try_files {path} {path}.html html/{path}.html
+        redir /stockfish.wasm /js/stockfish.wasm
         file_server
 
 }

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -11,7 +11,8 @@ RUN sed -i "s#APP_URL#${APP_URL}#g" /var/www/html/static/js/game.js      # for d
 RUN apk add npm && npm install && apk add minify
 RUN cp /var/www/html/node_modules/chess.js/dist/cjs/chess.js /var/www/html/static/js/chess.js && \
     cp /var/www/html/node_modules/@chrisoakman/chessboardjs/dist/chessboard-1.0.0.min.css /var/www/html/static/css/chessboard-1.0.0.min.css && \
-    cp /var/www/html/node_modules/@chrisoakman/chessboardjs/dist/chessboard-1.0.0.min.js /var/www/html/static/js/chessboard-1.0.0.min.js
+    cp /var/www/html/node_modules/@chrisoakman/chessboardjs/dist/chessboard-1.0.0.min.js /var/www/html/static/js/chessboard-1.0.0.min.js && \
+    cp /var/www/html/node_modules/stockfish/src/stockfish* /var/www/html/static/js/
 RUN minify -o /var/www/html/static/js/chess.min.js /var/www/html/static/js/chess.js
 
 RUN cp /var/www/html/Caddyfile /etc/caddy/Caddyfile

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,7 +10,7 @@
     "@chrisoakman/chessboardjs": "^1.0.0",
     "chess.js": "v1.0.0-beta.8",
     "requirejs": "^2.3.7",
-    "stockfish.wasm": "^0.10.0"
+    "stockfish": "11.0.0"
   },
   "keywords": [],
   "author": "",

--- a/src/frontend/static/html/game.html
+++ b/src/frontend/static/html/game.html
@@ -8,17 +8,13 @@
         <title>Chessmine</title>
         <!-- Bootstrap CSS -->
         <link rel="stylesheet" href="../css/bootstrap.css">
-        <link rel="stylesheet" href="../vendors/linericon/style.css">
         <link rel="stylesheet" href="../css/font-awesome.min.css">
-        <link rel="stylesheet" href="../vendors/owl-carousel/owl.carousel.min.css">
         <link rel="stylesheet" href="../css/magnific-popup.css">
-        <link rel="stylesheet" href="../vendors/nice-select/css/nice-select.css">
         <link rel="stylesheet" href="../vendors/animate-css/animate.css">
         <!-- main css -->
         <link rel="stylesheet" href="../css/style.css">
         <link rel="stylesheet" href="../css/game.css">
         <link rel="stylesheet" href="../css/settings.css">
-        <link rel="stylesheet" href="static/css/responsive.css">
         <link rel="stylesheet" href="../css/chessboard-1.0.0.min.css">
         <link rel="stylesheet" href="../css/loading.css">
         <link rel="stylesheet" href="../css/endgame.css">
@@ -240,10 +236,6 @@
                 referrerpolicy="no-referrer">
         </script>
         <script src="../js/theme.js"></script>
-        <script src="../vendors/nice-select/js/jquery.nice-select.min.js"></script>
-        <script src="../vendors/isotope/imagesloaded.pkgd.min.js"></script>
-        <script src="../vendors/isotope/isotope-min.js"></script>
-        <script src="../vendors/owl-carousel/owl.carousel.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ajaxchimp/1.3.0/jquery.ajaxchimp.min.js"
                 integrity="sha512-5yj5elY9u6clGe9/97bj3jJlw8+O9XSv/tbme8m/LR8cKnnT5+rR8qHW/UYQ/MozLg3cvTHeYIpM5kRktASSbg=="
                 crossorigin="anonymous"
@@ -251,11 +243,11 @@
         </script>
         <script src="../vendors/counter-up/jquery.waypoints.min.js"></script>
         <script src="../vendors/counter-up/jquery.counterup.min.js"></script>
-        <script src="../vendors/lightbox/simpleLightbox.min.js"></script>
         <!-- contact js -->
         <script>var exports = {};</script>
         <script src="../js/chess.min.js"></script>
         <script src="../js/chessboard-1.0.0.min.js"></script>
+        <script src="../js/stockfish.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js"
                 integrity="sha512-YUkaLm+KJ5lQXDBdqBqk7EVhJAdxRnVdT2vtCzwPHSweCzyMgYV/tgGF4/dCyqtCC2eCphz0lRQgatGVdfR0ww=="
                 crossorigin="anonymous"

--- a/src/frontend/static/js/stockfish_handler.js
+++ b/src/frontend/static/js/stockfish_handler.js
@@ -1,0 +1,35 @@
+var stockfish = null;
+
+function stockfish_load(moves) {
+  if (!stockfish) {
+    let threads = window.navigator.hardwareConcurrency || 1;
+    var movesSteps = '';
+    if (moves !== undefined && moves.length > 0) {
+        movesSteps += 'moves ';
+        movesSteps += moves.join(' ');
+    }
+    console.log('Loading stockfish with moves: ' + movesSteps);
+
+    stockfish = STOCKFISH();
+    stockfish.postMessage('uci');
+    stockfish.postMessage('ucinewgame');
+    stockfish.postMessage(`setoption name Threads value ${threads}`);
+    stockfish.postMessage("setoption name Skill Level value 10");
+    stockfish.postMessage(`position startpos ` + movesSteps);
+    stockfish.postMessage('isready');
+  }
+  return stockfish;
+}
+
+function stockfish_move(movesList) {
+    let movetime = 1000;
+    if (movesList !== undefined && movesList.length > 0) {
+        movesList = 'moves ' + movesList;
+    }
+    console.log('The moves list: ' + movesList);
+    stockfish.postMessage('ucinewgame');
+    stockfish.postMessage(`position startpos ${movesList}`);
+    stockfish.postMessage(`go movetime ${movetime}`);
+}
+
+export { stockfish_load, stockfish_move }


### PR DESCRIPTION
This PR adds support for engine play. The engine is created on client-side and each move is generated after the player move. The move is sent to the server-side as a regular move and then the client gets it back through the "move" socket endpoint, and it is treated as a regular opponent move. So the call is sent to the server and back before it is processed as a move on the client side.